### PR TITLE
chore: Aligned NPM dev and peer dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,11 +67,11 @@
         "typescript": "^5.4.5"
     },
     "peerDependencies": {
-        "@nestjs/common": "^10.2.10",
-        "@nestjs/core": "^10.2.10",
-        "@typegoose/typegoose": "^11.7.1",
-        "mongoose": "^8.0.1",
-        "reflect-metadata": "^0.1.13",
-        "rxjs": "^7.5.6 || <9.0.0"
+        "@nestjs/common": "^10.3.8",
+        "@nestjs/core": "^10.3.8",
+        "@typegoose/typegoose": "^12.5.0",
+        "mongoose": "^8.4.0",
+        "reflect-metadata": "^0.2.2",
+        "rxjs": "^7.8.1"
     }
 }


### PR DESCRIPTION
At the moment the NPM package versions in `package.json` do not align for 

`devDependencies`

https://github.com/GrapeoffJS/kindagoose/blob/b3c3dca74c004bfead12b86c8d96da0f801b90c0/package.json#L49

 and `peerDependencies`:

https://github.com/GrapeoffJS/kindagoose/blob/b3c3dca74c004bfead12b86c8d96da0f801b90c0/package.json#L72

This concerns `@nestjs/common`, `@nestjs/core`, `@typegoose/typegoose`, `mongoose`, `reflect-metadata` and `rxjs`.

While the version for `@typegoose/typegoose` was supposed to be updated specifically by https://github.com/GrapeoffJS/kindagoose/issues/216, it only led to `devDependencies` being updated.